### PR TITLE
Dropping Python 3.6 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9, '3.10']
+                python: [3.7, 3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9, '3.10']
+                python: [3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v1
             - name: Setup Python

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py37, py38, py39, py310
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This pull request aims to drop support for Python 3.6 as it is not compatible with the "ubuntu-latest" environment used in our workflow configuration. The "ubuntu-latest" environment provides the latest Ubuntu operating system for our CI/CD pipelines, but it does not include Python 3.6.

By dropping Python 3.6 support, we can streamline our workflow configuration and focus on supporting the more recent Python versions that are compatible with the "ubuntu-latest" environment.

Please review and merge this pull request to reflect the updated support requirements. Thank you!