### PR TITLE
Use urllib3 1.26.16

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.22.0
 requests_toolbelt==0.10.1
-urllib3==1.26.15
+urllib3==1.26.16

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.22.0
 requests_toolbelt==0.10.1
-urllib3==1.26.16
+urllib3==1.26.17

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,4 @@ coverage==4.5.4
 tox==3.14.2
 responses==0.17.0
 requests_toolbelt==0.10.1
-urllib3==1.26.15
+urllib3==1.26.16


### PR DESCRIPTION
Updates requirements to use urllib3 1.26.16.

Context: Celery 5.3.x required urllib3 1.26.16, and using imagekit at the same time causes a dependency resolution failure.